### PR TITLE
Fix always appended comma

### DIFF
--- a/gamemode/gui/scoreboard.lua
+++ b/gamemode/gui/scoreboard.lua
@@ -415,7 +415,7 @@ local SPECS_BOARD =
 
 			if(Spectators:find( pl:Nick()) == nil ) then
 
-			Spectators = Spectators..pl:Nick()..","
+				Spectators = Spectators == "" and pl:Nick() or Spectators .. ", " .. pl:Nick()
 
 			end
 		end


### PR DESCRIPTION
This little change just removes that comma that is always appended in the spectator's list.
