### PR TITLE
Update objhunt.txt

### DIFF
--- a/objhunt.txt
+++ b/objhunt.txt
@@ -1,7 +1,9 @@
 "objhunt"
 {
-	"base"       "base"
-	"title"      "Obj Hunt"
-	"maps"       "^ph_|^cs_"
-	"menusystem" "1"
+	"base		"base"
+	"title		"Obj Hunt"
+	"maps		"^ph_|^de_|^cs_"
+	
+	"menusystem"	"1"
+	"workshopid"	"302390067"
 }


### PR DESCRIPTION
This is just a suggestion. I would like to add the de_\* maps to Obj Hunt in the Singleplayer Menu like in the original Prop Hunt Gamemode. And more importantly I would like to add the workshop id of the addon. This makes the server telling the client to download the Gamemode's Workshop addon. In addition you don't need to download the taunts through the server anymore that are already in the gamemode. (Maybe just let the server search for taunts in the garrysmod root directory?)
